### PR TITLE
Fix a bunch of typos in API documentation.

### DIFF
--- a/source/includes/_cm.md
+++ b/source/includes/_cm.md
@@ -24,7 +24,7 @@ curl "https://a.mapillary.com/v2/cm/v-fa0oYnRnpy6vzbmGRTCQ?client_id=<CLIENT_ID>
 }
 ```
 
-Retrive information about a specific comment.
+Retrieve information about a specific comment.
 
 ### Scopes
 

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -7,7 +7,7 @@
 ```curl
 200 OK - Everything worked as expected.
 400 Bad Request - Often missing required parameters.
-401 Unauthorized - Your client_id is invalid, the oauth token is invalid, client_id and oauth token do not match.
+401 Unauthorized - Your client_id is invalid, the OAuth token is invalid, client_id and OAuth token do not match.
 404 Not Found - The API does not exist, the requested object does not exist.
 429 Too Many Requests - You're requesting over your limit.
 500 Internal Server Error - Something went wrong on Mapillary's servers.
@@ -21,7 +21,7 @@ Error Code | Meaning | Description
 ---------- | ------- | -----------
 200 | OK | Everything worked as expected.
 400 | Bad Request | Often missing required parameters.
-401 | Unauthorized | Your client_id is invalid, the oauth token is invalid, client_id and oauth token do not match.
+401 | Unauthorized | Your client_id is invalid, the OAuth token is invalid, client_id and OAuth token do not match.
 404 | Not Found | The API does not exist, the requested object does not exist.
 429 | Too Many Requests | You're requesting over your limit.
 500 | Internal Server Error | Something went wrong on Mapillary's servers.

--- a/source/includes/_im.md
+++ b/source/includes/_im.md
@@ -463,7 +463,7 @@ or_rectversions[rects] | Detections in form of rectangles
 or_rectversions[rects][rect] | Rectangle of detection in normalized coordinates (0 to 1) [North West X, North West Y, South East X, South East Y]
 or_rectversions[rects][type] | Type of match
 or_rectversions[rects][user_defined] | True if defined by user
-or_rectversions[timestamp] | Version and also timestamp of registred version match agains confirmations
+or_rectversions[timestamp] | Version and also timestamp of registered version match against confirmations
 or_rectversions[user] | User performing detection
 or_rectversions[package] | Package feeding back against
 or_done | True if all detections are run on image
@@ -475,8 +475,8 @@ or_confirmed_packages[version] | Version of detection that is confirmed
 
 ## POST /im/:key/or/version
 
-Create a detected version. Not yet availble.
+Create a detected version. Not yet available.
 
 ## POST /im/:key/or/version/approve
 
-Approve a detected version. Not yet availble.
+Approve a detected version. Not yet available.

--- a/source/includes/_images_sequences.md
+++ b/source/includes/_images_sequences.md
@@ -33,7 +33,7 @@ This license applies to all four versions of the photos, named "thumb-320.jpg", 
 
 Attribution should include a clearly visible link to mapillary.com or to the Mapillary photo page directly.
 
-The images are also available under other licenses for commerical use if CC BY-SA is not appropriate for the commercial usage. 
+The images are also available under other licenses for commercial use if CC BY-SA is not appropriate for the commercial usage. 
 
 Mapillary images are available using the following URL pattern:
 

--- a/source/includes/_me.md
+++ b/source/includes/_me.md
@@ -39,15 +39,15 @@ user:email | Access to users email
 Parameter | Description
 --------- | -----------
 about | Text about user
-avatar | Url to user avatar
+avatar | URL to user avatar
 member_since | When user created account in EPOCH ms
 username | Username of user
-user_uuid | Unqiue identifier of user in Mapillary system
+user_uuid | Unique identifier of user in Mapillary system
 email | Users email if correct scope is authenticated
 
 ## PUT /me
 
-TBD not yet availble.
+TBD not yet available.
 
 ## GET /me/feed
 
@@ -79,7 +79,7 @@ curl "https://a.mapillary.com/v2/me/feed?client_id=<CLIENT_ID>"
 }
 ```
 
-Retrive a users feed.
+Retrieve a users feed.
 
 ### Scopes
 
@@ -103,15 +103,15 @@ Parameter | Description
 --------- | -----------
 feed | Array of events in the feed sorted by newest first
 feed[action] | Action or feed event
-feed[timestamp] | When event happend
-feed[object] | Type of object operetared at
+feed[timestamp] | When event happened
+feed[object] | Type of object operated at
 feed[key] | Key of object
 feed[user] | User responsible for action
 feed[other_use] | Secondary user in action
 feed[image_url] | Link to an image representing the event
 feed[main_description] | Main description
 feed[detail_description] | Longer and more detailed description of event
-feed[location] | Location where event happend
+feed[location] | Location where event happened
 feed[version] | Version of feed event
 
 ## GET /me/uploads/secrets
@@ -133,7 +133,7 @@ curl "https://a.mapillary.com/v2/me/uploads/secrets?client_id=<CLIENT_ID>"
 }
 ```
 
-Retrive user specific hashes to use S3 direct upload for images.
+Retrieve user specific hashes to use S3 direct upload for images.
 
 ### Scopes
 
@@ -151,8 +151,8 @@ Parameter | Description
 --------- | -----------
 images_policy | Policy to upload to Mapillary images S3 folder
 images_hash | Hash to upload to Mapillary images S3 folder
-videos_policy: Policy to upload to Mapillary videos S3 folder
-videos_hash: Hash to upload to Mapillary videos S3 folder
+videos_policy | Policy to upload to Mapillary videos S3 folder
+videos_hash | Hash to upload to Mapillary videos S3 folder
 
 ## GET /me/uploads/status
 

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -1,6 +1,6 @@
 # OAuth
 
-The Mapillary API lets you interect with Mapillary on the behalf of a user. This is achived by using OAuth 2.0. Mapillary supports the implicit and code flow of the OAuth [2.0 specification](http://tools.ietf.org/html/rfc6749).
+The Mapillary API lets you interact with Mapillary on the behalf of a user. This is achieved by using OAuth 2.0. Mapillary supports the implicit and code flow of the OAuth [2.0 specification](http://tools.ietf.org/html/rfc6749).
 
 Mapillary OAuth tokens do not have any expiration time. The user can at any time revoke the token directly from the settings page..
 
@@ -44,11 +44,11 @@ code | string | The authorization code obtained when user is sent to redirect_ur
 
 ## Scopes
 
-The following scopes are availble.
+The following scopes are available.
 
 Name | Description
 ---- | -----------
-mapillary:user    | This scope is only availble to native Mapillary applications
+mapillary:user    | This scope is only available to native Mapillary applications
 user:read         | Access to all private information about user
 user:write        | Ability to update a users information
 user:email        | Access to users email
@@ -56,7 +56,7 @@ public:write      | Update users public objects
 public:upload     | Upload public images on behalf of the user
 private:read      | Read users private objects
 private:write     | Update users private objects
-private:upload    | UPload private images for the user
+private:upload    | Upload private images for the user
 org:read          | Read users organizations and projects
 org:write         | Update users organizations and projects
 

--- a/source/includes/_s.md
+++ b/source/includes/_s.md
@@ -41,7 +41,7 @@ curl "https://a.mapillary.com/v2/s/XXhG1IuvngsFAw-zRrk6cg?client_id=<CLIENT_ID>"
 }
 ```
 
-Retrive information about a specific sequence.
+Retrieve information about a specific sequence.
 
 ### Scopes
 
@@ -128,7 +128,7 @@ curl "https://a.mapillary.com/v2/s/XXhG1IuvngsFAw-zRrk6cg/geojson?client_id=<CLI
 }
 ```
 
-Retrive information about a specific sequence in geojson format.
+Retrieve information about a specific sequence in geojson format.
 
 ### Scopes
 

--- a/source/includes/_search.md
+++ b/source/includes/_search.md
@@ -99,7 +99,7 @@ client_id | The client id of your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show public
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -151,7 +151,7 @@ curl "https://a.mapillary.com/v2/search/im/close?client_id=<CLIENT_ID>&lat=55.87
   }
 ```
 
-Get images close to a certain point defined my longitude, latitude, max angle, min angle and a radius in meters.
+Get images close to a certain point defined by longitude, latitude, max angle, min angle and a radius in meters.
 
 ### Scopes
 
@@ -169,7 +169,7 @@ client_id | The client id belonging to your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show all none projects
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 lat | Latitude to search in circle from
@@ -338,7 +338,7 @@ client_id | The client id belonging to your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show all none projects
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -397,7 +397,7 @@ curl "https://a.mapillary.com/v2/search/im/cm?client_id=<CLIENT_ID>"
 }
 ```
 
-Get all images that have atleast one comment in an area.
+Get all images that have at least one comment in an area.
 
 ### Scopes
 
@@ -415,7 +415,7 @@ client_id | The client id belonging to your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show all none projects
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -607,7 +607,7 @@ rects[score] | Confidence score of match
 rects[type] | Classification of match
 rects[rect] | Rectangle of match in normalized coordinates (0 to 1) [North West X, North West Y, South East X, South East Y]
 orversions | List of recognition versions
-orversions[timestamp] | Version and also timestamp of registered version match agains confirmations
+orversions[timestamp] | Version and also timestamp of registered version match against confirmations
 orversions[package] | Object recognition package
 orversions[user] | user who created the version of the recognition
 orversions[rects] | Matches in form of rectangles
@@ -639,7 +639,7 @@ curl "https://a.mapillary.com/v2/search/im/s/uwDS-P5HcC9BfMghANb3Pw?client_id=<C
 }
 ```
 
-Search for an image giving a sequence. If a point is provied (lat, lon), closest image will be returned.
+Search for an image given a sequence. If a point is provided (lat, lon), closest image will be returned.
 
 ### HTTP Request
 
@@ -713,7 +713,7 @@ client_id | The client id of your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show public
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -762,7 +762,7 @@ curl "https://a.mapillary.com/v2/search/im/geojson/close?client_id=<CLIENT_ID>&l
 }
 ```
 
-Get images close to a certain point defined my longitude, latitude, max angle, min angle and a radius in meters in geojson format.
+Get images close to a certain point defined by longitude, latitude, max angle, min angle and a radius in meters in geojson format.
 
 ### Scopes
 
@@ -780,7 +780,7 @@ client_id | The client id belonging to your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show all none projects
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 lat | Latitude to search in circle from
@@ -846,7 +846,7 @@ client_id | The client id of your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show public
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -913,7 +913,7 @@ client_id | The client id of your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show public
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -981,7 +981,7 @@ client_id | The client id of your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show public
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -1066,14 +1066,14 @@ client_id | The client id belonging to your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show all none projects
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
 max_lat | Maximum Latitude
 min_lon | Minimum Longitude
 max_lon | Maximum Longitude
-or_package | Package to search in (availble "trafficsign_eu_1.0" and "trafficsign_us_1.0")
+or_package | Package to search in (available "trafficsign_eu_1.0" and "trafficsign_us_1.0")
 or_classes[] | Arrays of classes to search for. Search are on prefix "prohibitory" will match both "prohibitory_no_parking" and "prohibitory_no_traffic_both_ways". While "prohibitory_no_parking" will only match "prohibitory_no_parking". For a list of classes see [Object Recognition Classes](/#object-recognition-classes).
 min_score | Minimal category score
 limit | Results per page in pagination
@@ -1177,7 +1177,7 @@ client_id | The client id of your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show public
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -1299,7 +1299,7 @@ client_id | The client id of your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show public
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -1371,7 +1371,7 @@ client_id | The client id of your application
 start_time | Start time in EPOCH ms
 end_time | End time in EPOCH ms
 project | If added show only objects for that project, if not show public
-hidden | Also show hidden images, only fot authed user though
+hidden | Also show hidden images, only for authed user though
 me | Just objects for logged in user
 user | Just objects for specific user
 min_lat | Minimum Latitude
@@ -1433,4 +1433,4 @@ Parameter | Description
 --------- | -----------
 matches[] | List of matched users
 matches[username] | Matched username
-matches[avatar] | If availble link to avatar of matched username
+matches[avatar] | If available link to avatar of matched username

--- a/source/includes/_u.md
+++ b/source/includes/_u.md
@@ -37,7 +37,7 @@ curl "https://a.mapillary.com/v2/u/gyllen?client_id=<CLIENT_ID>"
 }
 ```
 
-Retrive public information and stats about a Mapillary user.
+Retrieve public information and stats about a Mapillary user.
 
 ### Scopes
 
@@ -55,11 +55,11 @@ user | Username of user wanted for lookup
 
 Parameter | Description
 --------- | -----------
-about | Descrpitive user entered text about user
+about | Descriptive user entered text about user
 avatar | Users avatar image
 distance_all | Distance mapped in meters by user
 histogram | Users uploads the last year, day by day
-images_none_processed | Public images uploded that entered the Mapillary system but are not fully processed
+images_none_processed | Public images uploaded that entered the Mapillary system but are not fully processed
 images_hidden | Public images hidden by user
 images_all | Total amount of public images uploaded by user
 user | username
@@ -95,7 +95,7 @@ curl "https://a.mapillary.com/v2/u/gyllen/feed?client_id=<CLIENT_ID>"
 }
 ```
 
-Retrive a users feed.
+Retrieve a users feed.
 
 ### HTTP Request
 
@@ -114,15 +114,15 @@ Parameter | Description
 --------- | -----------
 feed | Array of events in the feed sorted by newest first
 feed[action] | Action or feed event
-feed[timestamp] | When event happend
-feed[object] | Type of object operetared at
+feed[timestamp] | When event happened
+feed[object] | Type of object operated at
 feed[key] | Key of object
 feed[user] | User responsible for action
 feed[other_use] | Secondary user in action
 feed[image_url] | Link to an image representing the event
 feed[main_description] | Main description
 feed[detail_description] | Longer and more detailed description of event
-feed[location] | Location where event happend
+feed[location] | Location where event happened
 feed[version] | Version of feed event
 
 ## GET /u/:user/profile.png
@@ -135,7 +135,7 @@ curl "https://a.mapillary.com/v2/u/gyllen/profile.png?client_id=<CLIENT_ID>"
 
 > The above command redirects to the users profile picture
 
-Retrive a users profile image.
+Retrieve a users profile image.
 
 ### HTTP Request
 

--- a/source/includes/_vectortiles.md
+++ b/source/includes/_vectortiles.md
@@ -63,7 +63,7 @@ You can access Mapillary data through vector tiles. We are using the [Mapbox vec
 
 The data tiles have layers that you can interact with, for example to do hover animations and show basic information.
 
-The tile url pattern is:
+The tile URL pattern is:
 
 `https://d2munx5tg0hw47.cloudfront.net/tiles/{z}/{x}/{y}.mapbox`
 


### PR DESCRIPTION
Note I didn't review grammar and wording, just obvious word typos and some capitalization of acronyms.