### PR TITLE
OAuth documentation lists incorrect response_types

### DIFF
--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -28,7 +28,7 @@ state | string | Any value included here will be appended to the redirect URI
 
 ## Finish Authorization
 
-The OAuth2 token endpoint. This endpoint accepts POST requests and is used to provision access tokens once a user has authorized your application.
+The OAuth2 token endpoint (used in the "authorization code" flow, ie. response_type=code). This endpoint accepts POST requests and is used to provision access tokens once a user has authorized your application.
 
 ### HTTP Request
 

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -22,7 +22,7 @@ Parameter | Type | Description
 --------- | ------- | -----------
 client_id | string | The client id belonging to your application
 redirect_uri | string | The redirect uri you have configured for your application
-response_type | enumeration | (implicit, token)
+response_type | enumeration | (code, token)
 scope | string | The scopes to request from the user using %20 (space) as delimiter
 state | string | Any value included here will be appended to the redirect URI
 


### PR DESCRIPTION
The OAuth documentation says Mapillary supports the implicit and code flows of OAuth 2.0. The “Request Authorization” documentation, describing the `/connect` authorization endpoint, says valid values for `response_type` are `implicit` and `token`.

However, the OAuth specification ([RFC 6749](http://tools.ietf.org/html/rfc6749)) says `token` *is* the implicit grant flow. The valid values are `token` for implicit flow and `code` for authorization code grant.

This matches the actual behavior of the API. That is, I tested it and the API follows the RFC in this aspect, but the Mapillary API documentation is incorrect. Passing `response_type=implicit` returns `error=unsupported_response_type`.